### PR TITLE
fix(exercise): replace std::result_of with std::invoke_result since the old one is deprecated in C++20;

### DIFF
--- a/exercises/7/7.1/thread_pool.hpp
+++ b/exercises/7/7.1/thread_pool.hpp
@@ -11,6 +11,7 @@
 #ifndef THREAD_POOL_H
 #define THREAD_POOL_H
 
+#include <type_traits>
 #include <vector>               // std::vector
 #include <queue>                // std::queue
 #include <memory>               // std::make_shared
@@ -96,7 +97,7 @@ inline ThreadPool::ThreadPool(size_t threads): stop(false) {
 template<class F, class... Args>
 decltype(auto) ThreadPool::enqueue(F&& f, Args&&... args) {
     // deduce return type
-    using return_type = typename std::result_of<F(Args...)>::type;
+    using return_type = typename std::invoke_result<F,Args...>::type;
 
     // fetch task
     auto task = std::make_shared<std::packaged_task<return_type()>>(


### PR DESCRIPTION
<!-- English Version -->

## Description

refer to https://en.cppreference.com/w/cpp/types/result_of , std::result_of was deprecated since C++ 20

When I build the exercise code with following clang++:
```
─╯
Apple clang version 14.0.3 (clang-1403.0.22.14.1)
Target: arm64-apple-darwin23.0.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
```

I got error:
```
clang++ main.cpp -o main.out -std=c++2a -pedantic
In file included from main.cpp:19:
./thread_pool.hpp:99:39: error: no type named 'result_of' in namespace 'std'
    using return_type = typename std::result_of<F(Args...)>::type;
                        ~~~~~~~~~~~~~~^~~~~~~~~
./thread_pool.hpp:99:48: error: expected ';' after alias declaration
    using return_type = typename std::result_of<F(Args...)>::type;
                                               ^
                                               ;
./thread_pool.hpp:102:53: error: use of undeclared identifier 'return_type'
    auto task = std::make_shared<std::packaged_task<return_type()>>(
                                                    ^
./thread_pool.hpp:102:53: error: template argument for template type parameter must be a type
    auto task = std::make_shared<std::packaged_task<return_type()>>(
                                                    ^~~~~~~~~~~~~
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1/future:1558:20: note: template parameter is declared here
    template <class> friend class packaged_task;
                   ^
In file included from main.cpp:19:
./thread_pool.hpp:106:17: error: use of undeclared identifier 'return_type'
    std::future<return_type> res = task->get_future();
                ^
5 errors generated.
make: *** [main.out] Error 1
```

## Change List
- replace the deprecated type in exercises/7/7.1
- 
## Reference

[std::result_of](https://en.cppreference.com/w/cpp/types/result_of)
