### PR TITLE
Clarify safety of `std::unique_ptr`

### DIFF
--- a/book/en-us/05-pointers.md
+++ b/book/en-us/05-pointers.md
@@ -82,7 +82,7 @@ std::cout << "pointer3.use_count() = "
 
 ## 5.3 `std::unique_ptr`
 
-`std::unique_ptr` is an exclusive smart pointer that prohibits other smart pointers from sharing the same object, thus keeping the code safe:
+`std::unique_ptr` is an exclusive smart pointer that prohibits other smart pointers from sharing the same object by copy construction or copy assignment, thus avoiding errors due to repeated destruction or freeing:
 
 ```cpp
 std::unique_ptr<int> pointer = std::make_unique<int>(10); // make_unique, from C++14

--- a/book/zh-cn/05-pointers.md
+++ b/book/zh-cn/05-pointers.md
@@ -80,7 +80,7 @@ std::cout << "pointer3.use_count() = "
 
 ## 5.3 `std::unique_ptr`
 
-`std::unique_ptr` 是一种独占的智能指针，它禁止其他智能指针与其共享同一个对象，从而保证代码的安全：
+`std::unique_ptr` 是一种独占的智能指针，它禁止其他智能指针经由拷贝构造或拷贝赋值的方式与其共享同一个对象，从而避免重复析构或释放带来的错误：
 
 ```cpp
 std::unique_ptr<int> pointer = std::make_unique<int>(10); // make_unique 从 C++14 引入


### PR DESCRIPTION
resolve #282

<!-- English Version -->

## Description

Clarify under which conditions `unique_ptr` guarantees safety, because it can't introduce absolute safety.

## Change List

- Add description regarding the non-copyability of `unique_ptr`

## Reference

- [`std::unique_ptr<T,Deleter>::unique_ptr` - cppreference.com](https://en.cppreference.com/w/cpp/memory/unique_ptr/unique_ptr)
- [`std::unique_ptr<T,Deleter>::operator=` - cppreference.com](https://en.cppreference.com/w/cpp/memory/unique_ptr/operator%3D)
- [[unique.ptr.single.ctor]](https://eel.is/c++draft/unique.ptr.single.ctor)
- [[unique.ptr.single.asgn]](https://eel.is/c++draft/unique.ptr.single.asgn)
- [[unique.ptr.runtime.ctor]](https://eel.is/c++draft/unique.ptr.runtime.ctor)
- [[unique.ptr.runtime.asgn]](https://eel.is/c++draft/unique.ptr.runtime.asgn)

---

<!-- 中文版 -->

## 说明

澄清 `unique_ptr` 在何种情况下保证安全，因为它不可能带来绝对的安全。

## 变化箱单

- 增加了 `unique_ptr` 不可复制相关的说明

## 参考文献

- [`std::unique_ptr<T,Deleter>::unique_ptr` - cppreference.com](https://zh.cppreference.com/w/cpp/memory/unique_ptr/unique_ptr)
- [`std::unique_ptr<T,Deleter>::operator=` - cppreference.com](https://zh.cppreference.com/w/cpp/memory/unique_ptr/operator%3D)
- [[unique.ptr.single.ctor]](https://eel.is/c++draft/unique.ptr.single.ctor)
- [[unique.ptr.single.asgn]](https://eel.is/c++draft/unique.ptr.single.asgn)
- [[unique.ptr.runtime.ctor]](https://eel.is/c++draft/unique.ptr.runtime.ctor)
- [[unique.ptr.runtime.asgn]](https://eel.is/c++draft/unique.ptr.runtime.asgn)