### PR TITLE
Clarify how does program terminate due to `noexcept`

### DIFF
--- a/book/en-us/09-others.md
+++ b/book/en-us/09-others.md
@@ -39,9 +39,9 @@ void may_throw();           // May throw any exception
 void no_throw() noexcept;   // Cannot throw any exception
 ```
 
-If a function modified with `noexcept` is thrown,
-the compiler will use `std::terminate()` to
-immediately terminate the program.
+If a function marked `noexcept` performs an operation that possibly throws an exception,
+the compiler will insert a `std::terminate()` call to the path exiting the function via an exception,
+in order to make the program terminate.
 
 `noexcept` can also be used as an operator to manipulate an expression.
 When the expression has no exception, it returns `true`,

--- a/book/zh-cn/09-others.md
+++ b/book/zh-cn/09-others.md
@@ -36,7 +36,7 @@ void may_throw(); // 可能抛出异常
 void no_throw() noexcept; // 不可能抛出异常
 ```
 
-使用 `noexcept` 修饰过的函数如果抛出异常，编译器会使用 `std::terminate()` 来立即终止程序运行。
+如果使用 `noexcept` 标记过的函数进行可能抛出异常的操作，编译器会在通过异常退出函数的路径上插入 `std::terminate()` 的调用，以使得程序终止运行。
 
 `noexcept` 还能够做操作符，用于操作一个表达式，当表达式无异常时，返回 `true`，否则返回 `false`。
 


### PR DESCRIPTION
<!-- English Version -->

## Description

Clarify that the compiler only inserts `std::terminate` calls, rather than terminate the program itself.

## Change List

- Resolve error content of `noexept`-caused termination

## Reference

- [[except.spec]/5](https://eel.is/c++draft/except.spec#5)
- [`noexcept` specifier - cppreference.com (since C++11)](https://en.cppreference.com/w/cpp/language/noexcept_spec)

---

<!-- 中文版 -->

## 说明

澄清编译器只会插入 `std::terminate` 调用，而不会亲自终止程序。

## 变化箱单

- 解决了关于 `noexcept` 导致程序终止的描述性错误

## 参考文献

- [[except.spec]/5](https://eel.is/c++draft/except.spec#5)
- [`noexcept` 说明符 - cppreference.com (C++11 起)](https://en.cppreference.com/w/cpp/language/noexcept_spec)