### PR TITLE
Make the examples for init-statements in if-statements consistent between Chinese and English versions

### DIFF
--- a/book/en-us/02-usability.md
+++ b/book/en-us/02-usability.md
@@ -203,18 +203,19 @@ E.g:
 int main() {
     std::vector<int> vec = {1, 2, 3, 4};
 
-    // since c++17, can be simplified by using `auto`
+    // before C++17, can be simplified by using `auto`
     const std::vector<int>::iterator itr = std::find(vec.begin(), vec.end(), 2);
     if (itr != vec.end()) {
         *itr = 3;
     }
 
-    if (const std::vector<int>::iterator itr = std::find(vec.begin(), vec.end(), 3);
-        itr != vec.end()) {
-        *itr = 4;
+    // need to define a new variable
+    const std::vector<int>::iterator itr2 = std::find(vec.begin(), vec.end(), 3);
+    if (itr2 != vec.end()) {
+        *itr2 = 4;
     }
 
-    // should output: 1, 4, 3, 4. can be simplified using `auto`
+    // will output: 1, 4, 3, 4; can be simplified using `auto`
     for (std::vector<int>::iterator element = vec.begin(); element != vec.end(); 
         ++element)
         std::cout << *element << std::endl;
@@ -227,6 +228,7 @@ the entire `std::vector` again. C++17 eliminates this limitation so that
 we can do this in if(or switch):
 
 ```cpp
+// put the temporary variable into the if-statement
 if (const std::vector<int>::iterator itr = std::find(vec.begin(), vec.end(), 3);
     itr != vec.end()) {
     *itr = 4;

--- a/book/zh-cn/02-usability.md
+++ b/book/zh-cn/02-usability.md
@@ -163,7 +163,7 @@ constexpr int fibonacci(const int n) {
 int main() {
     std::vector<int> vec = {1, 2, 3, 4};
 
-    // 在 c++17 之前
+    // 在 C++17 之前，能用 `auto` 简化
     const std::vector<int>::iterator itr = std::find(vec.begin(), vec.end(), 2);
     if (itr != vec.end()) {
         *itr = 3;
@@ -175,7 +175,7 @@ int main() {
         *itr2 = 4;
     }
 
-    // 将输出 1, 4, 3, 4
+    // 将输出 1, 4, 3, 4；能用 `auto` 简化
     for (std::vector<int>::iterator element = vec.begin(); element != vec.end(); 
         ++element)
         std::cout << *element << std::endl;


### PR DESCRIPTION
resolve #298

<!-- English Version -->

## Description

Fix the example in the English version, making the examples consistent between both versions.

## Change List

## Reference

---

<!-- 中文版 -->

## 说明

对中文版的例子补充注释。使得版本间的例子一致。

## 变化箱单

## 参考文献
