### PR TITLE
Add missing `;` to the end of definition of `buffer_t`

### DIFF
--- a/book/en-us/02-usability.md
+++ b/book/en-us/02-usability.md
@@ -880,7 +880,7 @@ public:
     void free(T& item);
 private:
     T data[BufSize];
-}
+};
 
 buffer_t<int, 100> buf; // 100 as template parameter
 ```

--- a/book/zh-cn/02-usability.md
+++ b/book/zh-cn/02-usability.md
@@ -788,7 +788,7 @@ public:
     void free(T& item);
 private:
     T data[BufSize];
-}
+};
 
 buffer_t<int, 100> buf; // 100 作为模板参数
 ```


### PR DESCRIPTION
resolve #302

<!-- English Version -->

## Description

Adds the missing ending `;` in the definition of `buffer_t` in `02-usability.md`.

## Change List

- Resolve error content of `book/en-us/02-usability.md`

## Reference

---

<!-- 中文版 -->

## 说明

添加缺失的结尾 `;` 到 `02-usability.md` 中 `buffer_t` 的定义。

## 变化箱单

- 解决了 `book/en-us/02-usability.md` 的描述性错误

## 参考文献