### PR TITLE
book: fix std::bind example with no return value

### DIFF
--- a/book/en-us/03-runtime.md
+++ b/book/en-us/03-runtime.md
@@ -214,14 +214,14 @@ and then complete the call after the parameters are complete. e.g:
 
 ```cpp
 int foo(int a, int b, int c) {
-    ;
+    return a + b + c;
 }
 int main() {
     // bind parameter 1, 2 on function foo,
     // and use std::placeholders::_1 as placeholder for the first parameter.
-    auto bindFoo = std::bind(foo, std::placeholders::_1, 1,2);
+    auto bindFoo = std::bind(foo, std::placeholders::_1, 1, 2);
     // when call bindFoo, we only need one param left
-    bindFoo(1);
+    std::cout << bindFoo(1) << std::endl; // outputs 4
 }
 ```
 

--- a/book/zh-cn/03-runtime.md
+++ b/book/zh-cn/03-runtime.md
@@ -188,14 +188,14 @@ int main() {
 
 ```cpp
 int foo(int a, int b, int c) {
-    ;
+    return a + b + c;
 }
 int main() {
     // 将参数1,2绑定到函数 foo 上，
     // 但使用 std::placeholders::_1 来对第一个参数进行占位
-    auto bindFoo = std::bind(foo, std::placeholders::_1, 1,2);
+    auto bindFoo = std::bind(foo, std::placeholders::_1, 1, 2);
     // 这时调用 bindFoo 时，只需要提供第一个参数即可
-    bindFoo(1);
+    std::cout << bindFoo(1) << std::endl; // 输出 4
 }
 ```
 


### PR DESCRIPTION
In §3.2 the `foo` in the `std::bind` example was declared to return `int` but had an empty body — undefined behavior (falling off the end of a non-`void` function). It now returns `a + b + c` and prints the result. Verified to compile under `-Wall -Wextra -Werror` and print `4`.

Fixes #305