### PR TITLE
book: clarify that typeof is not a standard C++ feature

### DIFF
--- a/book/en-us/02-usability.md
+++ b/book/en-us/02-usability.md
@@ -448,8 +448,10 @@ std::cout << add20(i, j) << std::endl;
 
 ### decltype
 
-The `decltype` keyword is used to solve the defect that the auto keyword
-can only type the variable. Its usage is very similar to `typeof`:
+The `decltype` keyword is used to solve the defect that the `auto` keyword
+can only deduce the type of a variable. Its usage is very similar to `typeof`,
+a non-standard extension long provided by some compilers (e.g. GCC and Clang)
+that was eventually standardized in C23 but has never been part of standard C++:
 
 ```cpp
 decltype(expression)

--- a/book/zh-cn/02-usability.md
+++ b/book/zh-cn/02-usability.md
@@ -384,7 +384,7 @@ std::cout << add20(i, j) << std::endl;
 
 ### decltype
 
-`decltype` 关键字是为了解决 `auto` 关键字只能对变量进行类型推导的缺陷而出现的。它的用法和 `typeof` 很相似：
+`decltype` 关键字是为了解决 `auto` 关键字只能对变量进行类型推导的缺陷而出现的。它的用法和 `typeof` 很相似（`typeof` 是 GCC、Clang 等编译器长期提供的非标准扩展，虽然最终在 C23 中被标准化，但从未成为 C++ 的标准特性）：
 
 ```cpp
 decltype(表达式)


### PR DESCRIPTION
`typeof` was presented as a familiar feature, but it is a non-standard extension (GCC/Clang) that was standardized only in C23 and has never been part of standard C++. Add a clarifying note in both languages.

Fixes #286