### PR TITLE
book: clarify value category is a property of expressions

### DIFF
--- a/book/en-us/03-runtime.md
+++ b/book/en-us/03-runtime.md
@@ -241,6 +241,13 @@ and making the function object container `std::function` possible.
 To understand what the rvalue reference is all about, you must have a clear
 understanding of the lvalue and the rvalue.
 
+> Strictly speaking, **a value category is a property of an *expression*, not of an
+> object**: every C++ expression belongs to exactly one of the three primary value
+> categories — lvalue, prvalue (pure rvalue), and xvalue (expiring value). The phrasings
+> below ("an lvalue is a persistent object", "an rvalue is a temporary object") are
+> intuitive approximations meant to help beginners; for the rigorous definitions, see
+> [cppreference: value category](https://en.cppreference.com/w/cpp/language/value_category).
+
 **lvalue, left value**, as the name implies, is the value to the left of the assignment
 symbol. To be precise, an lvalue is a persistent object that still exists after
 an expression (not necessarily an assignment expression).
@@ -252,7 +259,7 @@ In C++11, in order to introduce powerful rvalue references,
 the concept of rvalue values ​​is further divided into:
 prvalue, and xvalue.
 
-**pvalue, pure rvalue**, purely rvalue, either purely literal,
+**prvalue, pure rvalue**, purely rvalue, either purely literal,
 such as `10`, `true`; either the result of the evaluation is equivalent to
 a literal or anonymous temporary object, for example `1+2`.
 Temporary variables returned by non-references, temporary variables generated

--- a/book/zh-cn/03-runtime.md
+++ b/book/zh-cn/03-runtime.md
@@ -212,6 +212,8 @@ int main() {
 
 要弄明白右值引用到底是怎么一回事，必须要对左值和右值做一个明确的理解。
 
+> 严格来说，**值类别 (value category) 是表达式的性质，而不是对象的性质**：每个 C++ 表达式都恰好属于三种基本值类别之一——左值 (lvalue)、纯右值 (prvalue)、将亡值 (xvalue)。下文中“左值是持久对象”“右值是临时对象”一类的说法，是为了便于初学者建立直觉的近似描述；严谨的定义请参阅 [cppreference：值类别](https://zh.cppreference.com/w/cpp/language/value_category)。
+
 **左值** (lvalue, left value)，顾名思义就是赋值符号左边的值。准确来说，
 左值是表达式（不一定是赋值表达式）后依然存在的持久对象。
 


### PR DESCRIPTION
The lvalue/rvalue section defined value categories in terms of objects, obscuring that value category is a property of *expressions* (each expression is exactly one of lvalue/prvalue/xvalue). Add a clarifying note citing cppreference while keeping the intuitive descriptions as labeled approximations. Also fix a `pvalue` → `prvalue` typo.

Fixes #275