### PR TITLE
book: explain range-based for loop internals

### DIFF
--- a/book/en-us/02-usability.md
+++ b/book/en-us/02-usability.md
@@ -653,6 +653,28 @@ int main() {
 }
 ```
 
+A range-based for loop is essentially syntactic sugar. The compiler expands
+
+```cpp
+for (range_declaration : range_expression) loop_statement
+```
+
+roughly into (since C++17):
+
+```cpp
+{
+    auto && __range = range_expression;
+    auto __begin = begin_expr; // __range for an array; __range.begin() or begin(__range) for a class
+    auto __end = end_expr;     // __range + N for an array; __range.end() or end(__range) for a class
+    for (; __begin != __end; ++__begin) {
+        range_declaration = *__begin;
+        loop_statement
+    }
+}
+```
+
+Therefore, any type that provides usable `begin()` and `end()` (member functions, or free functions found via ADL) whose returned iterators support `!=`, dereference `*`, and pre-increment `++` can be traversed by a range-based for loop — which is exactly how you make a custom container work with it.
+
 ## 2.5 Templates
 
 C++ templates have always been a special art of the language, and templates can even be used independently as a new language. The philosophy of the template is to throw all the problems that can be processed at compile time into the compile time, and only deal with those core dynamic services at runtime, to greatly optimize the performance of the runtime. Therefore, templates are also regarded by many as one of the black magic of C++.

--- a/book/zh-cn/02-usability.md
+++ b/book/zh-cn/02-usability.md
@@ -567,6 +567,28 @@ int main() {
 }
 ```
 
+基于范围的 for 循环本质上只是语法糖，编译器会把
+
+```cpp
+for (range_declaration : range_expression) loop_statement
+```
+
+大致展开为（C++17 起）：
+
+```cpp
+{
+    auto && __range = range_expression;
+    auto __begin = begin_expr; // 数组为 __range，类类型为 __range.begin() 或 begin(__range)
+    auto __end = end_expr;     // 数组为 __range + N，类类型为 __range.end() 或 end(__range)
+    for (; __begin != __end; ++__begin) {
+        range_declaration = *__begin;
+        loop_statement
+    }
+}
+```
+
+因此，只要一个类型提供了可用的 `begin()` 与 `end()`（成员函数，或可通过 ADL 找到的自由函数），并且返回的迭代器支持 `!=`、解引用 `*` 与前置 `++`，它就能被基于范围的 for 循环遍历——这也正是让自定义容器支持区间 for 的方法。
+
 ## 2.5 模板
 
 C++ 的模板一直是这门语言的一种特殊的艺术，模板甚至可以独立作为一门新的语言来进行使用。模板的哲学在于将一切能够在编译期处理的问题丢到编译期进行处理，仅在运行时处理那些最核心的动态服务，进而大幅优化运行期的性能。因此模板也被很多人视作 C++ 的黑魔法之一。


### PR DESCRIPTION
Add the (C++17) desugaring of the range-based for loop and note that any type with usable `begin()`/`end()` and iterators supporting `!=`, `*`, and pre-`++` can be traversed — how to enable range-for for custom containers. Verified with a minimal custom container example.

Fixes #158