### PR TITLE
code: sync and extend examples with recent book fixes

### DIFF
--- a/code/2/2.11.for.loop.cpp
+++ b/code/2/2.11.for.loop.cpp
@@ -10,6 +10,17 @@
 #include <iostream>
 #include <vector>
 #include <algorithm>
+#include <cstddef>
+
+// A minimal custom container: any type that provides usable begin()/end()
+// (whose iterators support !=, * and pre-++) can be used with range-based for,
+// because the loop is just syntactic sugar over those operations.
+struct IntRange {
+    int* data;
+    std::size_t n;
+    int* begin() const { return data; }
+    int* end()   const { return data + n; }
+};
 
 int main() {
     std::vector<int> vec = {1, 2, 3, 4};
@@ -21,4 +32,11 @@ int main() {
     }
     for (auto element : vec)
         std::cout << element << std::endl; // read only
+
+    // range-based for over a user-defined container
+    int arr[] = {10, 20, 30};
+    IntRange range{arr, 3};
+    for (auto&& x : range)
+        std::cout << x << ' ';
+    std::cout << std::endl;
 }

--- a/code/3/3.2.function.wrap.cpp
+++ b/code/3/3.2.function.wrap.cpp
@@ -20,7 +20,7 @@ int foo2(int para) {
 }
 
 int foo3(int a, int b, int c) {
-    return 0;
+    return a + b + c;
 }
 
 int main() {
@@ -43,9 +43,9 @@ int main() {
 
     // bind parameter 1, 2 on function foo, and use std::placeholders::_1 as placeholder
     // for the first parameter.
-    auto bindFoo = std::bind(foo3, std::placeholders::_1, 1,2);
+    auto bindFoo = std::bind(foo3, std::placeholders::_1, 1, 2);
     // when call bindFoo, we only need one param left
-    bindFoo(1);
+    std::cout << bindFoo(1) << std::endl; // outputs 4
 
     return 0;
 }

--- a/code/4/4.3.tuples.cpp
+++ b/code/4/4.3.tuples.cpp
@@ -11,6 +11,7 @@
 #include <tuple>
 #include <iostream>
 #include <variant>
+#include <utility>
 
 auto get_student(int id)
 {
@@ -40,6 +41,25 @@ constexpr std::variant<T...> tuple_index(const std::tuple<T...>& tpl, size_t i) 
 template <typename T>
 auto tuple_len(T &tpl) {
     return std::tuple_size<T>::value;
+}
+
+// idiomatic traversal: C++17 fold expression + std::index_sequence
+template <typename Func, typename Tuple, std::size_t... idx>
+void iterate_impl(Func&& f, Tuple&& tpl, std::index_sequence<idx...>) {
+    (f(std::get<idx>(std::forward<Tuple>(tpl))), ...);
+}
+template <typename Func, typename Tuple>
+void iterate_tuple(Func&& f, Tuple&& tpl) {
+    iterate_impl(std::forward<Func>(f), std::forward<Tuple>(tpl),
+        std::make_index_sequence<std::tuple_size_v<std::remove_reference_t<Tuple>>>{});
+}
+
+// idiomatic traversal: C++20 lambda with explicit template parameters
+template <typename Func, typename... Args>
+void iterate_tuple_cpp20(Func f, const std::tuple<Args...>& tpl) {
+    [&]<std::size_t... idx>(std::index_sequence<idx...>) {
+        (f(std::get<idx>(tpl)), ...);
+    }(std::make_index_sequence<sizeof...(Args)>());
 }
 
 template <typename T0, typename ... Ts>
@@ -76,8 +96,17 @@ int main()
     // concat
     auto new_tuple = std::tuple_cat(get_student(1), std::move(t));
     
-    // iteration
+    // iteration via runtime indexing
     for(int i = 0; i != tuple_len(new_tuple); ++i) {
         std::cout << tuple_index(new_tuple, i) << std::endl; // runtime indexing
     }
+
+    // idiomatic traversal (C++17 fold + index_sequence)
+    auto print = [](const auto& v) { std::cout << v << ' '; };
+    iterate_tuple(print, new_tuple);
+    std::cout << std::endl;
+
+    // idiomatic traversal (C++20 templated lambda)
+    iterate_tuple_cpp20(print, new_tuple);
+    std::cout << std::endl;
 }


### PR DESCRIPTION
Keeps the runnable `code/` examples consistent with the recently merged book fixes (#305, #294, #158).

- **`code/3/3.2.function.wrap.cpp`** — `foo3` now returns `a + b + c` and the bound result is printed (matches #305).
- **`code/4/4.3.tuples.cpp`** — adds the idiomatic tuple traversal (C++17 fold + `std::index_sequence`, and the C++20 templated-lambda form) from #294.
- **`code/2/2.11.for.loop.cpp`** — adds a minimal custom container traversed by a range-based for, illustrating the internals from #158.

All three verified with the project build command `clang++ -std=c++2a -pedantic` (compile **and** run).

Related: #305, #294, #158 (already merged).