### PR TITLE
code: fix concepts example to valid C++20 syntax

### DIFF
--- a/code/10/10.2.concepts.cpp
+++ b/code/10/10.2.concepts.cpp
@@ -12,17 +12,18 @@
 #include <string>
 #include <vector>
 #include <list>
+#include <concepts>
 
 using namespace std;
 
  template<typename T>
-concept bool Stringable = requires(T a){
-    {a.to_string()} -> string;
+concept Stringable = requires(T a){
+    {a.to_string()} -> std::convertible_to<std::string>;
 };
 
  template<typename T>
-concept bool HasStringFunc = requires(T a){
-    { to_string(a) } -> string;
+concept HasStringFunc = requires(T a){
+    { to_string(a) } -> std::convertible_to<std::string>;
 };
 
 struct Person {
@@ -55,11 +56,11 @@ string to_string(std::vector<int> v){
 }
 
 
- void print(Stringable a){
+ void print(Stringable auto a){
     std::cout << a.to_string() << std::endl;
 }
 
- void print(HasStringFunc a){
+ void print(HasStringFunc auto a){
     std::cout << to_string(a) << std::endl;
 }
 


### PR DESCRIPTION
`code/10/10.2.concepts.cpp` used the **Concepts TS** syntax that was removed before C++20 was finalized, so it did not compile under the project build (`clang++ -std=c++2a`). Per [cppreference: Constraints and concepts](https://en.cppreference.com/w/cpp/language/constraints):

- `concept bool Name = ...` → `concept Name = ...`
- `{ a.to_string() } -> string;` → `{ a.to_string() } -> std::convertible_to<std::string>;`
- `void print(Stringable a)` → `void print(Stringable auto a)`

Added `<concepts>` for `std::convertible_to`. Verified it now compiles **and runs** with `clang++ -std=c++2a -pedantic`.

Fixes #316