### PR TITLE
book: add C++17 inline variables, nested namespaces, constexpr lambda

### DIFF
--- a/book/en-us/02-usability.md
+++ b/book/en-us/02-usability.md
@@ -1097,6 +1097,52 @@ At this point, the following code will be able to be compiled:
 std::cout << new_enum::value3 << std::endl
 ```
 
+## 2.7 Other Language Features
+
+### Inline variables
+
+Before C++17, a non-const static data member of a class had to be defined separately outside the class, and defining a global variable in a header would cause duplicate-definition link errors when the header was included by multiple translation units. C++17 introduces `inline` variables, which allow a variable (including a static data member) to be defined in a header without violating the One Definition Rule (ODR), even when included by multiple translation units:
+
+```cpp
+struct Widget {
+    static inline int count = 0; // C++17: define and initialize a static member in-class
+};
+inline int global_value = 42;    // safe to place in a header
+```
+
+This greatly simplifies writing header-only libraries.
+
+### Nested namespace definitions
+
+C++17 allows writing nested namespace definitions in a single line using `::`, instead of indenting level by level:
+
+```cpp
+// before C++17
+namespace A {
+    namespace B {
+        namespace C {
+            int value;
+        }
+    }
+}
+
+// since C++17
+namespace A::B::C {
+    int value;
+}
+```
+
+### constexpr lambda
+
+Since C++17, a lambda expression that satisfies the requirements of a constant expression is implicitly `constexpr` (and may also be explicitly marked `constexpr`), so it can be evaluated at compile time:
+
+```cpp
+constexpr auto add = [](int a, int b) { return a + b; };
+static_assert(add(1, 2) == 3, "");
+
+constexpr int result = add(3, 4); // evaluated at compile time, result == 7
+```
+
 ## Conclusion
 
 This section introduces the enhancements to language usability in modern C++, which I believe are the most important features that almost everyone needs to know and use:

--- a/book/zh-cn/02-usability.md
+++ b/book/zh-cn/02-usability.md
@@ -1011,6 +1011,52 @@ std::ostream& operator<<(
 std::cout << new_enum::value3 << std::endl
 ```
 
+## 2.7 其他语言特性
+
+### 内联变量
+
+在 C++17 之前，类的非常量静态成员变量必须在类外单独定义，而在头文件中定义全局变量则会因为被多个翻译单元包含而导致重复定义的链接错误。C++17 引入了 `inline` 变量，允许在头文件中定义变量（包括类的静态成员），即便被多个翻译单元包含也不会违反单一定义规则 (ODR)：
+
+```cpp
+struct Widget {
+    static inline int count = 0; // C++17：在类内定义并初始化静态成员
+};
+inline int global_value = 42;    // 可安全地放在头文件中
+```
+
+这极大地简化了「仅有头文件」的库的编写。
+
+### 嵌套命名空间
+
+C++17 允许使用 `::` 一次性书写嵌套命名空间的定义，不再需要层层缩进：
+
+```cpp
+// C++17 之前
+namespace A {
+    namespace B {
+        namespace C {
+            int value;
+        }
+    }
+}
+
+// C++17 起
+namespace A::B::C {
+    int value;
+}
+```
+
+### constexpr lambda
+
+从 C++17 开始，满足常量表达式要求的 Lambda 表达式会隐式地成为 `constexpr`（也可以显式标注 `constexpr`），从而能够在编译期求值：
+
+```cpp
+constexpr auto add = [](int a, int b) { return a + b; };
+static_assert(add(1, 2) == 3, "");
+
+constexpr int result = add(3, 4); // 在编译期求值，result == 7
+```
+
 ## 总结
 
 本节介绍了现代 C++ 中对语言可用性的增强，其中笔者认为最为重要的几个特性是几乎所有人都需要了解并熟练使用的：

--- a/code/2/2.21.inline.variable.cpp
+++ b/code/2/2.21.inline.variable.cpp
@@ -1,0 +1,26 @@
+//
+// 2.21.inline.variable.cpp
+// chapter 2 language usability
+// modern cpp tutorial
+//
+// created by changkun at changkun.de
+// https://github.com/changkun/modern-cpp-tutorial
+//
+
+#include <iostream>
+
+struct Widget {
+    // C++17: define and initialize a static data member inside the class
+    static inline int count = 0;
+    Widget() { ++count; }
+};
+
+// C++17: an inline variable can be safely defined in a header and
+// included by multiple translation units without violating the ODR
+inline int global_value = 42;
+
+int main() {
+    Widget a, b, c;
+    std::cout << "Widget::count = " << Widget::count << std::endl; // 3
+    std::cout << "global_value = " << global_value << std::endl;   // 42
+}

--- a/code/2/2.22.nested.namespace.cpp
+++ b/code/2/2.22.nested.namespace.cpp
@@ -1,0 +1,19 @@
+//
+// 2.22.nested.namespace.cpp
+// chapter 2 language usability
+// modern cpp tutorial
+//
+// created by changkun at changkun.de
+// https://github.com/changkun/modern-cpp-tutorial
+//
+
+#include <iostream>
+
+// C++17: define nested namespaces in a single line
+namespace A::B::C {
+    int value = 1;
+}
+
+int main() {
+    std::cout << "A::B::C::value = " << A::B::C::value << std::endl; // 1
+}

--- a/code/2/2.23.constexpr.lambda.cpp
+++ b/code/2/2.23.constexpr.lambda.cpp
@@ -1,0 +1,20 @@
+//
+// 2.23.constexpr.lambda.cpp
+// chapter 2 language usability
+// modern cpp tutorial
+//
+// created by changkun at changkun.de
+// https://github.com/changkun/modern-cpp-tutorial
+//
+
+#include <iostream>
+
+int main() {
+    // C++17: a lambda that satisfies the constant-expression requirements
+    // is implicitly constexpr and can be evaluated at compile time
+    constexpr auto add = [](int a, int b) { return a + b; };
+    static_assert(add(1, 2) == 3, "evaluated at compile time");
+
+    constexpr int result = add(3, 4);
+    std::cout << "result = " << result << std::endl; // 7
+}


### PR DESCRIPTION
Adds a new §2.7 covering three self-contained C++17 language features that were missing from the book (tracked in #1):

- **inline variables** (including in-class static member initialization)
- **nested namespace definitions** (`namespace A::B::C`)
- **constexpr lambda**

Each has a runnable example mirrored under `code/2` (`2.21`–`2.23`), all verified to compile **and run** with `clang++ -std=c++2a -pedantic`.

Refs #1